### PR TITLE
Updated interacting-with-your-contracts.md for outdated web3 call

### DIFF
--- a/src/docs/truffle/getting-started/interacting-with-your-contracts.md
+++ b/src/docs/truffle/getting-started/interacting-with-your-contracts.md
@@ -213,7 +213,7 @@ instance.sendTransaction({...}).then(function(result) {
 Option 2: There's also shorthand for just sending Ether directly:
 
 ```javascript
-instance.send(web3.toWei(1, "ether")).then(function(result) {
+instance.send(web3.utils.toWei("1", "ether")).then(function(result) {
   // Same result object as above.
 });
 ```


### PR DESCRIPTION
Updated the outdated `web3.toWei` call to the latest `web3.utils.toWei` call in the truffle documentation: "Interacting with Your Contracts" section